### PR TITLE
feat: show a success message once the update finish on Linux and macOS

### DIFF
--- a/common/src/main/kotlin/utils/CommandLine.kt
+++ b/common/src/main/kotlin/utils/CommandLine.kt
@@ -9,8 +9,8 @@ import kotlin.io.path.absolutePathString
  * Run a command in the command line of the system
  * @param args The arguments that is used to run the command, the reason this is not a String to
  * prevent some issues and bugs with the paths or the arguments that have spacing
- * @param reasonOfRunningTheCommand This is used to tell the user why we're running this command on the system
- * should be something like `to check if the system in dark mode`
+ * @param reasonOfRunningTheCommand This is used to tell the user why we're running this command on the system.
+ * Should be something like `to check if the system in dark mode`
  * @param isLoggingEnabled Should we print the result, output and errors to the log?
  * */
 fun commandLine(
@@ -56,6 +56,16 @@ fun commandLine(
         Result.failure(e)
     }
 }
+
+/**
+ * Similar to [commandLine] without logging and waiting for the result.
+ * It doesn't handle the output or specific error to the output of the command.
+ * */
+fun commandLineNonBlocking(vararg args: String): Result<Unit> =
+    runCatching {
+        ProcessBuilder(listOf(*args))
+            .start()
+    }
 
 /**
  * Has the similar functionality as [commandLine] specifically for using powershell commands in Windows

--- a/common/src/test/kotlin/utils/CommandLineTest.kt
+++ b/common/src/test/kotlin/utils/CommandLineTest.kt
@@ -13,12 +13,18 @@ class CommandLineTest {
         assertThrows<IOException> {
             commandLine("java-incorrect", "--version", reasonOfRunningTheCommand = null).getOrThrow()
         }
+        assertThrows<IOException> {
+            commandLineNonBlocking("java-incorrect", "--version").getOrThrow()
+        }
     }
 
     @Test
     fun `test commandLine when using correct command`() {
         assertDoesNotThrow {
             commandLine("java", "--version", reasonOfRunningTheCommand = null).getOrThrow()
+        }
+        assertDoesNotThrow {
+            commandLineNonBlocking("java", "--version").getOrThrow()
         }
     }
 

--- a/sync-script/src/main/kotlin/services/updater/JarAutoUpdater.kt
+++ b/sync-script/src/main/kotlin/services/updater/JarAutoUpdater.kt
@@ -189,7 +189,7 @@ object JarAutoUpdater {
                             fileEntityType = "JAR",
                         )
 
-                        // The Application has been updated without automatically relaunch it, show a message
+                        // The Application has been updated without automatically relaunching it, showing a message
                         val (windowTitle, message) = buildUpdateSuccessMessage()
                         val commandArgs: Array<String> =
                             when (OperatingSystem.current) {

--- a/sync-script/src/main/kotlin/services/updater/JarAutoUpdater.kt
+++ b/sync-script/src/main/kotlin/services/updater/JarAutoUpdater.kt
@@ -11,12 +11,14 @@ import services.HttpResponse
 import utils.FileDownloader
 import utils.SystemInfoProvider
 import utils.buildHtml
+import utils.commandLineNonBlocking
 import utils.convertBytesToReadableMegabytesAsString
 import utils.createFileWithParentDirectoriesOrTerminate
 import utils.deleteExistingOrTerminate
 import utils.executeBatchScriptInSeparateWindow
 import utils.getRunningJarFilePath
 import utils.moveToOrTerminate
+import utils.os.LinuxDesktopEnvironment
 import utils.os.OperatingSystem
 import utils.terminateWithOrWithoutError
 import utils.version.SemanticVersion
@@ -89,6 +91,7 @@ object JarAutoUpdater {
                         ?.value
                 Result.success(projectVersion)
             }
+
             is HttpResponse.HttpFailure -> Result.failure(response.exception())
             is HttpResponse.UnknownError -> Result.failure(response.exception)
         }
@@ -185,6 +188,44 @@ object JarAutoUpdater {
                             overwrite = true,
                             fileEntityType = "JAR",
                         )
+
+                        // The Application has been updated without automatically relaunch it, show a message
+                        val (windowTitle, message) = buildUpdateSuccessMessage()
+                        val commandArgs: Array<String> =
+                            when (OperatingSystem.current) {
+                                OperatingSystem.Linux ->
+                                    when (LinuxDesktopEnvironment.current) {
+                                        LinuxDesktopEnvironment.KdePlasma ->
+                                            arrayOf(
+                                                "kdialog",
+                                                "--title",
+                                                windowTitle,
+                                                "--msgbox",
+                                                message,
+                                            )
+                                        else ->
+                                            arrayOf(
+                                                "zenity",
+                                                "--info",
+                                                "--title",
+                                                windowTitle,
+                                                "--text",
+                                                message,
+                                            )
+                                    }
+
+                                OperatingSystem.MacOS ->
+                                    arrayOf(
+                                        "osascript",
+                                        "-e",
+                                        "display dialog \"$message\" with title \"$windowTitle\" buttons {\"OK\"} default button \"OK\"",
+                                    )
+
+                                else -> error("The operating system is expected to be either Linux or macOS in the current check.")
+                            }
+                        commandLineNonBlocking(
+                            *commandArgs,
+                        ).getOrThrow()
                     },
                 )
             }
@@ -204,8 +245,7 @@ object JarAutoUpdater {
                 }
                 val secondsToWait = 1
 
-                val windowTitle = "Update Complete"
-                val message = "${ProjectInfoConstants.DISPLAY_NAME} has been updated. Relaunch to use the new version."
+                val (windowTitle, message) = buildUpdateSuccessMessage()
 
                 val messageVbsFilePath =
                     SyncScriptDotMinecraftFiles.SyncScriptData.Temp.path
@@ -239,4 +279,10 @@ object JarAutoUpdater {
         // Will require the user to launch once again after the update.
         terminateWithOrWithoutError()
     }
+
+    private fun buildUpdateSuccessMessage(): Pair<String, String> =
+        Pair(
+            "Update Complete",
+            "${ProjectInfoConstants.DISPLAY_NAME} has been updated. Relaunch to use the new version.",
+        )
 }


### PR DESCRIPTION
<details>
<summary>Windows</summary>

![Windows](https://github.com/FreshKernel/kraft-sync/assets/73608287/dc2584ae-584f-4ec1-8ff2-55ca8ecd3903)

</details>

<details>

<summary>Linux</summary

![Cinnamon/Gnome](https://github.com/FreshKernel/kraft-sync/assets/73608287/c49bf6d5-a5b0-42b8-9f75-952dfc2413d5)

![KDE](https://github.com/FreshKernel/kraft-sync/assets/73608287/f54076ae-e018-488a-9e97-378a3c9fd3bc)


</details>

<details>

<summary>macOS</summary

![macOS](https://github.com/FreshKernel/kraft-sync/assets/73608287/cfc77eb2-2bf0-4a6e-bf3a-8a22219420f0)


</details>