### PR TITLE
feat: logger class

### DIFF
--- a/admin/src/main/kotlin/minecraftAssetProviders/curseForge/data/RemoteCurseForgeDataSource.kt
+++ b/admin/src/main/kotlin/minecraftAssetProviders/curseForge/data/RemoteCurseForgeDataSource.kt
@@ -5,6 +5,7 @@ import minecraftAssetProviders.curseForge.models.CurseForgeModFileDownloadUrlRes
 import minecraftAssetProviders.curseForge.models.CurseForgeModFileResponse
 import services.HttpClient
 import services.HttpResponse
+import utils.Logger
 
 class RemoteCurseForgeDataSource : CurseForgeDataSource {
     companion object {
@@ -28,7 +29,7 @@ class RemoteCurseForgeDataSource : CurseForgeDataSource {
                 )
         ) {
             is HttpResponse.Success -> {
-                println("ℹ\uFE0F Curse Forge Mod ($modId) File ($fileId) Json Response: ${response.body}")
+                Logger.info { "ℹ\uFE0F Curse Forge Mod ($modId) File ($fileId) Json Response: ${response.body}" }
                 Result.success(response.decodeJson<CurseForgeModFileResponse>())
             }
 
@@ -52,7 +53,7 @@ class RemoteCurseForgeDataSource : CurseForgeDataSource {
             )
         return when (response) {
             is HttpResponse.Success -> {
-                println("ℹ\uFE0F Curse Forge Mod ($modId) File ($fileId) Download URL Json Response: ${response.body}")
+                Logger.info { "ℹ\uFE0F Curse Forge Mod ($modId) File ($fileId) Download URL Json Response: ${response.body}" }
                 Result.success(response.decodeJson<CurseForgeModFileDownloadUrlResponse>())
             }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -33,12 +33,14 @@ val generateBuildConfig =
     tasks.register<GenerateBuildConfigTask>("generateBuildConfig") {
         // To allow overriding the current project version
         val projectVersion: String? by project
+        val developmentMode: String? by project
 
         val buildConfigDirectory = project.layout.buildDirectory.dir("generated")
 
         classFullyQualifiedName.set("generated.BuildConfig")
         generatedOutputDirectory.set(buildConfigDirectory)
         fieldsToGenerate.put("PROJECT_VERSION", projectVersion ?: libs.versions.project.get())
+        fieldsToGenerate.put("DEVELOPMENT_MODE", developmentMode?.toBooleanStrictOrNull() ?: false)
     }
 
 sourceSets.main.configure {

--- a/common/src/main/kotlin/gui/utils/GuiUtils.kt
+++ b/common/src/main/kotlin/gui/utils/GuiUtils.kt
@@ -11,6 +11,7 @@ import com.formdev.flatlaf.themes.FlatMacLightLaf
 import constants.SharedAssetConstants
 import gui.theme.Theme
 import gui.theme.ThemeMode
+import utils.Logger
 import utils.getResourceAsURLOrThrow
 import utils.os.OperatingSystem
 import java.awt.Component
@@ -152,14 +153,14 @@ object GuiUtils {
             e.printStackTrace()
 
             if (e is UnsupportedLookAndFeelException) {
-                println(
-                    "⚠️ Couldn't switch to the selected theme \uD83C\uDFA8. It looks like this theme is not supported on your system.",
-                )
+                Logger.error {
+                    "⚠️ Couldn't switch to the selected theme \uD83C\uDFA8. It looks like this theme is not supported on your system."
+                }
                 return
             }
-            println(
-                "❌ Failed to switch to the selected theme \uD83C\uDFA8: ${e.message}",
-            )
+            Logger.error {
+                "❌ Failed to switch to the selected theme \uD83C\uDFA8: ${e.message}"
+            }
         }
     }
 

--- a/common/src/main/kotlin/gui/utils/ThemeDetector.kt
+++ b/common/src/main/kotlin/gui/utils/ThemeDetector.kt
@@ -1,5 +1,6 @@
 package gui.utils
 
+import utils.Logger
 import utils.SystemInfoProvider
 import utils.commandLine
 import utils.os.LinuxDesktopEnvironment
@@ -48,20 +49,20 @@ object ThemeDetector {
                             SystemInfoProvider.getUserHomeDirectoryPath(),
                             ".config/kdeglobals",
                         )
-                    println(
+                    Logger.info {
                         "\uD83D\uDCC4 Reading the following file to check if the KDE Plasma desktop environment " +
-                            "is in dark mode: ${kdeGlobalsFile.pathString}",
-                    )
+                            "is in dark mode: ${kdeGlobalsFile.pathString}"
+                    }
                     return try {
                         val lookAndFeelPackageName =
                             kdeGlobalsFile.bufferedReader().useLines { line ->
                                 line.firstOrNull { it.startsWith("LookAndFeelPackage=") }?.substringAfter('=')
                             }
-                        println("✨ The KDE Plasma look and feel package name: 🎨 $lookAndFeelPackageName")
+                        Logger.info { "✨ The KDE Plasma look and feel package name: 🎨 $lookAndFeelPackageName" }
                         Result.success(lookAndFeelPackageName)
                     } catch (e: Exception) {
                         e.printStackTrace()
-                        println("❌ Error while reading the file ${kdeGlobalsFile.name}: ${e.message}")
+                        Logger.error { "❌ Error while reading the file ${kdeGlobalsFile.name}: ${e.message}" }
                         Result.failure(e)
                     }
                 }

--- a/common/src/main/kotlin/utils/CommandLine.kt
+++ b/common/src/main/kotlin/utils/CommandLine.kt
@@ -27,7 +27,7 @@ fun commandLine(
                 }
                 append(": ${args.joinToString(" ")}")
             }
-        println(message)
+        Logger.info { message }
     }
     return try {
         val process =
@@ -39,18 +39,22 @@ fun commandLine(
             process.destroy()
             val errorMessage = "⏰ Process timed out for the command: ${args.joinToString(" ")}"
             if (isLoggingEnabled) {
-                println("❌ $errorMessage")
+                Logger.error { "❌ $errorMessage" }
             }
             return Result.failure(RuntimeException(errorMessage))
         }
         val result = process.inputStream.bufferedReader().use { it.readText() }
         if (isLoggingEnabled) {
-            println("✅ Command executed successfully: '${args.joinToString(" ")}'. " + "📜 Output: ${result.trim()}")
+            Logger.info {
+                "✅ Command executed successfully: '${args.joinToString(" ")}'. " + "📜 Output: ${result.trim()}"
+            }
         }
         Result.success(result)
     } catch (e: Exception) {
         if (isLoggingEnabled) {
-            println("❌ Error executing command `${args.joinToString(" ")}`: ${e.message}")
+            Logger.error {
+                "❌ Error executing command `${args.joinToString(" ")}`: ${e.message}"
+            }
         }
         e.printStackTrace()
         Result.failure(e)

--- a/common/src/main/kotlin/utils/Logger.kt
+++ b/common/src/main/kotlin/utils/Logger.kt
@@ -1,0 +1,46 @@
+package utils
+
+import generated.BuildConfig
+
+/**
+ * A simple logger that doesn't require additional dependencies and is not compatible
+ * with known logging solutions. Most of the messages will be shown to the user
+ * in case they run the application in CLI mode either in command-line or using the launcher,
+ * which is why don't use something like `[main] INFO Main - The log message` in production mode.
+ * */
+object Logger {
+    fun error(lazyMessage: () -> String) {
+        logMessage(lazyMessage = lazyMessage, logLevel = "Error")
+    }
+
+    fun debug(lazyMessage: () -> String) {
+        if (!BuildConfig.DEVELOPMENT_MODE) return
+        logMessage(lazyMessage = lazyMessage, logLevel = "Debug")
+    }
+
+    fun info(lazyMessage: () -> String) {
+        logMessage(lazyMessage = lazyMessage, logLevel = "Info")
+    }
+
+    fun warning(lazyMessage: () -> String) {
+        logMessage(lazyMessage = lazyMessage, logLevel = "Warning")
+    }
+
+    fun trace(lazyMessage: () -> String) {
+        logMessage(lazyMessage = lazyMessage, logLevel = "Trace")
+    }
+
+    private fun logMessage(
+        lazyMessage: () -> String,
+        logLevel: String,
+    ) {
+        val message =
+            buildString {
+                if (BuildConfig.DEVELOPMENT_MODE) {
+                    append("$logLevel - ")
+                }
+                append(lazyMessage())
+            }
+        println(message)
+    }
+}

--- a/common/src/main/kotlin/utils/Logger.kt
+++ b/common/src/main/kotlin/utils/Logger.kt
@@ -18,8 +18,15 @@ object Logger {
         logMessage(lazyMessage = lazyMessage, logLevel = "Debug")
     }
 
-    fun info(lazyMessage: () -> String) {
-        logMessage(lazyMessage = lazyMessage, logLevel = "Info")
+    fun info(
+        extraLine: Boolean = false,
+        lazyMessage: () -> String,
+    ) {
+        logMessage(
+            extraLine = extraLine,
+            lazyMessage = lazyMessage,
+            logLevel = "Info",
+        )
     }
 
     fun warning(lazyMessage: () -> String) {
@@ -31,11 +38,18 @@ object Logger {
     }
 
     private fun logMessage(
+        /**
+         * Add an extra new line before printing the message
+         * */
+        extraLine: Boolean = false,
         lazyMessage: () -> String,
         logLevel: String,
     ) {
         val message =
             buildString {
+                if (extraLine) {
+                    append("\n")
+                }
                 if (BuildConfig.DEVELOPMENT_MODE) {
                     append("$logLevel - ")
                 }

--- a/sync-script/src/main/kotlin/Main.kt
+++ b/sync-script/src/main/kotlin/Main.kt
@@ -25,6 +25,7 @@ import syncService.ResourcePacksSyncService
 import syncService.ServersSyncService
 import syncService.SyncService
 import utils.ExecutionTimer
+import utils.Logger
 import utils.SystemInfoProvider
 import utils.createFileWithParentDirectoriesOrTerminate
 import utils.deleteRecursivelyWithLegacyJavaIo
@@ -49,8 +50,8 @@ suspend fun main(args: Array<String>) {
 
     passedArgs = args
 
-    println("📋 Current project version: ${BuildConfig.PROJECT_VERSION}")
-    println("\uD83D\uDCC1 Current working directory: ${SystemInfoProvider.getCurrentWorkingDirectoryPath()}")
+    Logger.info { "📋 Current project version: ${BuildConfig.PROJECT_VERSION}" }
+    Logger.info { "\uD83D\uDCC1 Current working directory: ${SystemInfoProvider.getCurrentWorkingDirectoryPath()}" }
 
     logSystemInfo()
     handleTemporaryDirectory(isStart = true)
@@ -79,7 +80,7 @@ suspend fun main(args: Array<String>) {
 
     GuiState.updateIsGuiEnabled()
 
-    println("ℹ\uFE0F Script Configuration: ${ScriptConfig.instance}")
+    Logger.info { "ℹ\uFE0F Script Configuration: ${ScriptConfig.instance}" }
 
     // Switch to the themes specified by config
     if (GuiState.isGuiEnabled) {
@@ -108,28 +109,28 @@ private fun logSystemInfo() {
         OperatingSystem.MacOS -> "\uD83C\uDF4F You are using macOS \uF8FF. Welcome to the world of Apple \uD83C\uDF4E."
         OperatingSystem.Windows -> "\uD83E\uDE9F You are using Windows. Be safe!"
         OperatingSystem.Unknown -> "❓Your operating system couldn't be identified. Let's hope everything works smoothly."
-    }.also { println(it) }
+    }.also { Logger.info { it } }
 
     if (!GraphicsEnvironment.isHeadless()) {
         if (GuiUtils.isSystemInDarkMode) {
             "🌙 Welcome to the dark side! Your system is in dark mode. Enjoy the soothing darkness! 🌃"
         } else {
             "☀️ Brighten up your day! Your system is in the light mode. Embrace the light! 🌅"
-        }.also { println(it) }
+        }.also { Logger.info { it } }
     }
 }
 
 private fun handleTemporaryDirectory(isStart: Boolean) {
     SyncScriptDotMinecraftFiles.SyncScriptData.Temp.path.apply {
         if (exists()) {
-            println(
+            Logger.info {
                 if (isStart) {
                     "ℹ\uFE0F The temporary folder: $pathString exist. " +
                         "The script might not finished last time. Removing the folder."
                 } else {
                     "\uD83D\uDEAB Deleting the temporary folder: '$pathString' (no longer needed)."
-                },
-            )
+                }
+            }
             deleteRecursivelyWithLegacyJavaIo()
         }
     }
@@ -139,10 +140,10 @@ private suspend fun loadScriptConfig(): ScriptConfig {
     val scriptConfigFile = SyncScriptDotMinecraftFiles.SyncScriptData.ScriptConfig.path
     if (!scriptConfigFile.exists()) {
         if (GuiState.isGuiEnabled) {
-            println(
-                "Configuration Missing! ⚠\uFE0F. Since you're in GUI mode, we'll launch a quick " +
-                    "dialog to gather the necessary information",
-            )
+            Logger.info {
+                "ℹ\uFE0F Configuration Missing. Since you're in GUI mode, we'll launch a quick " +
+                    "dialog to gather the necessary information"
+            }
 
             val scriptConfig = CreateScriptConfigDialog().showDialog()
             runBlocking { scriptConfigDataSource.replaceConfig(scriptConfig) }
@@ -248,6 +249,8 @@ private suspend fun fetchSyncInfo() {
                 return
             }
 
+    Logger.debug { "\uD83D\uDC1E Sync Info: ${SyncInfo.instance}" }
+
     LoadingIndicatorDialog.instance?.updateComponentProperties(
         title = "Synchronization",
         infoText = "Performing initial checks and configurations...",
@@ -275,10 +278,10 @@ private suspend fun handleAdminTrustCheck() {
             // If the user doesn't say he/she trusts the admin yet, then we will ask him
             val doesUserTrustThisSource = TrustAdminDialog.showDialog()
             if (!doesUserTrustThisSource) {
-                println(
+                Logger.info {
                     "\uD83D\uDD12 Script is closing because trust in the administration is lacking. " +
-                        "Feel free to reach out if you have any concerns.",
-                )
+                        "Feel free to reach out if you have any concerns."
+                }
                 terminateWithOrWithoutError()
             }
             runBlocking {
@@ -315,9 +318,9 @@ private fun finalize(applicationExecutionTimer: ExecutionTimer) {
     // after finish syncing the contents successfully, we don't need it anymore.
     handleTemporaryDirectory(isStart = false)
 
-    println(
-        "\n\uD83C\uDF89 The script has successfully completed in " +
-            "(${applicationExecutionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms)! \uD83D\uDE80",
-    )
+    Logger.info(extraLine = true) {
+        "\uD83C\uDF89 The script has successfully completed in " +
+            "(${applicationExecutionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms)! \uD83D\uDE80"
+    }
     exitProcess(0)
 }

--- a/sync-script/src/main/kotlin/syncInfo/data/RemoteSyncInfoDataSource.kt
+++ b/sync-script/src/main/kotlin/syncInfo/data/RemoteSyncInfoDataSource.kt
@@ -3,11 +3,12 @@ package syncInfo.data
 import services.HttpClient
 import services.HttpResponse
 import syncInfo.models.SyncInfo
+import utils.Logger
 
 // TODO: I might add an option for caching the data/response or disable it. Similar to Next Js
 class RemoteSyncInfoDataSource : SyncInfoDataSource {
     override suspend fun fetchSyncInfo(url: String): Result<SyncInfo> {
-        println("\uD83D\uDCE5 Sending GET request to: $url")
+        Logger.info { "\uD83D\uDCE5 Sending GET request to: $url" }
         return when (val response = HttpClient.get(url = url)) {
             is HttpResponse.Success -> Result.success(response.decodeJson<SyncInfo>())
             is HttpResponse.HttpFailure ->

--- a/sync-script/src/main/kotlin/syncService/ModsSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ModsSyncService.kt
@@ -174,7 +174,7 @@ class ModsSyncService :
             val modFileName = getFileNameFromUrlOrError(mod.downloadUrl)
             val modFilePath = getModFilePath(mod)
             if (modFilePath.exists()) {
-                Logger.info { "⚠\uFE0F The mod: '$modFileName' already exists." }
+                Logger.warning { "⚠\uFE0F The mod: '$modFileName' already exists." }
             }
 
             Logger.info { "\uD83D\uDD3D Downloading mod '$modFileName' from ${mod.downloadUrl}" }

--- a/sync-script/src/main/kotlin/syncService/ModsSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ModsSyncService.kt
@@ -14,6 +14,7 @@ import syncInfo.models.shouldVerifyFileIntegrity
 import syncService.common.AssetSyncService
 import utils.ExecutionTimer
 import utils.FileDownloader
+import utils.Logger
 import utils.calculateProgressByIndex
 import utils.convertBytesToReadableMegabytesAsString
 import utils.deleteExistingOrTerminate
@@ -41,17 +42,17 @@ class ModsSyncService :
         withContext(Dispatchers.IO) {
             val executionTimer = ExecutionTimer()
             executionTimer.setStartTime()
-            println("\n\uD83D\uDD04 Syncing mods...")
+            Logger.info(extraLine = true) { "\uD83D\uDD04 Syncing mods..." }
 
             // Mods from the remote
             val mods = modSyncInfo.mods
-            println("📥 Total received mods from server: ${mods.size}")
+            Logger.info { "📥 Total received mods from server: ${mods.size}" }
 
             validateAssetDirectory()
             deleteUnSyncedLocalModFiles(mods = mods)
 
             val currentEnvironmentModsOrAll = getCurrentEnvironmentModsOrAll(mods = mods)
-            println("📥 Current environment mods: ${currentEnvironmentModsOrAll.size}")
+            Logger.info { "📥 Current environment mods: ${currentEnvironmentModsOrAll.size}" }
 
             LoadingIndicatorDialog.instance?.updateComponentProperties(
                 title = "Syncing Mods...",
@@ -66,14 +67,16 @@ class ModsSyncService :
                 getModsForDownloadAndValidateIfRequired(
                     mods = currentEnvironmentModsOrAll,
                 )
-            println("\n🔍 Mods to download: ${modsToDownload.size}")
+            Logger.info(extraLine = true) { "🔍 Mods to download: ${modsToDownload.size}" }
 
             downloadMods(
                 modsToDownload = modsToDownload,
                 totalMods = currentEnvironmentModsOrAll,
             )
 
-            println("\uD83D\uDD52 Finished syncing the mods in ${executionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms.")
+            Logger.info {
+                "\uD83D\uDD52 Finished syncing the mods in ${executionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms."
+            }
         }
 
     private suspend fun deleteUnSyncedLocalModFiles(mods: List<Mod>) {
@@ -87,7 +90,7 @@ class ModsSyncService :
         val remoteModFileNames: List<String> = mods.map { getModFilePath(it).name }
         for (localModFilePath in localModFilePathsToProcess) {
             if (localModFilePath.name !in remoteModFileNames) {
-                println("\uD83D\uDEAB Deleting the mod '${localModFilePath.name}' as it's no longer on the server.")
+                Logger.info { "\uD83D\uDEAB Deleting the mod '${localModFilePath.name}' as it's no longer on the server." }
                 localModFilePath.deleteExistingOrTerminate(
                     fileEntityType = "mod",
                     reasonOfDelete = "it's no longer on the server",
@@ -109,7 +112,7 @@ class ModsSyncService :
 
                 val modFilePath = getModFilePath(mod)
                 if (modFilePath.exists()) {
-                    println("❌ Deleting the mod '${modFilePath.name}' as it's not needed on the current environment.")
+                    Logger.info { "\uD83D\uDEAB Deleting the mod '${modFilePath.name}' as it's not needed on the current environment." }
                     modFilePath.deleteExistingOrTerminate(
                         fileEntityType = "mod",
                         reasonOfDelete = "it's not required on the current environment",
@@ -127,7 +130,7 @@ class ModsSyncService :
             val modFilePath = getModFilePath(mod)
             if (modFilePath.exists()) {
                 if (!mod.shouldVerifyFileIntegrity()) {
-                    println("ℹ️ The mod: '$modFileName' is set to not be verified. Skipping to the next mod.")
+                    Logger.info { "ℹ️ The mod: '$modFileName' is set to not be verified. Skipping to the next mod." }
                     return@filter false
                 }
 
@@ -142,17 +145,16 @@ class ModsSyncService :
                 )
                 val hasValidModFileIntegrity = mod.hasValidFileIntegrityOrError(modFilePath)
                 if (hasValidModFileIntegrity == null) {
-                    println("❓ The mod: '$modFileName' has an unknown integrity. Skipping to the next mod.")
+                    Logger.info { "❓ The mod: '$modFileName' has an unknown integrity. Skipping to the next mod." }
                     return@filter false
                 }
                 if (hasValidModFileIntegrity) {
-                    println("✅ The mod: '$modFileName' has valid file integrity. Skipping to the next mod.")
+                    Logger.info { "✅ The mod: '$modFileName' has valid file integrity. Skipping to the next mod." }
                     return@filter false
                 }
-                println(
-                    "❌ The mod: '$modFileName' has invalid integrity. Deleting the mod " +
-                        "and downloading it again.",
-                )
+                Logger.info {
+                    "\uD83D\uDEAB The mod: '$modFileName' has invalid integrity. Deleting the mod and downloading it again."
+                }
                 modFilePath.deleteExistingOrTerminate(
                     fileEntityType = "mod",
                     reasonOfDelete = "it has invalid file integrity",
@@ -172,10 +174,10 @@ class ModsSyncService :
             val modFileName = getFileNameFromUrlOrError(mod.downloadUrl)
             val modFilePath = getModFilePath(mod)
             if (modFilePath.exists()) {
-                println("⚠\uFE0F The mod: '$modFileName' already exists.")
+                Logger.info { "⚠\uFE0F The mod: '$modFileName' already exists." }
             }
 
-            println("\uD83D\uDD3D Downloading mod '$modFileName' from ${mod.downloadUrl}")
+            Logger.info { "\uD83D\uDD3D Downloading mod '$modFileName' from ${mod.downloadUrl}" }
 
             FileDownloader(
                 downloadUrl = mod.downloadUrl,

--- a/sync-script/src/main/kotlin/syncService/ResourcePacksSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ResourcePacksSyncService.kt
@@ -152,9 +152,7 @@ class ResourcePacksSyncService :
             val resourcePackFileName = getFileNameFromUrlOrError(resourcePack.downloadUrl)
             val resourcePackFilePath = getResourcePackFilePath(resourcePack)
             if (resourcePackFilePath.exists()) {
-                Logger.warning {
-                    "⚠\uFE0F The resource-pack: '$resourcePackFileName' already exists."
-                }
+                Logger.warning { "⚠\uFE0F The resource-pack: '$resourcePackFileName' already exists." }
             }
 
             Logger.info { "\uD83D\uDD3D Downloading resource-pack '$resourcePackFileName' from ${resourcePack.downloadUrl}" }

--- a/sync-script/src/main/kotlin/syncService/ServersSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ServersSyncService.kt
@@ -17,6 +17,7 @@ import net.benwoodworth.knbt.put
 import syncInfo.models.SyncInfo
 import syncInfo.models.instance
 import utils.ExecutionTimer
+import utils.Logger
 import utils.buildHtml
 import utils.isFileEmpty
 import utils.showErrorMessageAndTerminate
@@ -47,7 +48,7 @@ class ServersSyncService : SyncService {
         val executionTimer = ExecutionTimer()
         executionTimer.setStartTime()
 
-        println("\n\uD83D\uDD04 Syncing server list...")
+        Logger.info(extraLine = true) { "\uD83D\uDD04 Syncing server list..." }
 
         val currentRootCompound =
             loadServersDatFile().getOrElse {
@@ -105,7 +106,9 @@ class ServersSyncService : SyncService {
             return
         }
 
-        println("\uD83D\uDD52 Finished syncing the server list in ${executionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms.")
+        Logger.info {
+            "\uD83D\uDD52 Finished syncing the server list in ${executionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms."
+        }
     }
 
     private fun loadServersDatFile(): Result<NbtCompound> {
@@ -121,7 +124,7 @@ class ServersSyncService : SyncService {
                     exitProcess(1)
                 }
                 if (serversDatFilePath.isFileEmpty()) {
-                    println("ℹ️ The file '${serversDatFilePath.name}' exists and is currently empty.")
+                    Logger.info { "ℹ️ The file '${serversDatFilePath.name}' exists and is currently empty." }
                     return Result.success(createEmptyServerCompound())
                 }
                 return Result.success(

--- a/sync-script/src/main/kotlin/syncService/common/AssetSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/common/AssetSyncService.kt
@@ -1,6 +1,7 @@
 package syncService.common
 
 import syncService.SyncService
+import utils.Logger
 import utils.buildHtml
 import utils.getFileNameFromUrlOrError
 import utils.listFilteredPaths
@@ -25,7 +26,7 @@ abstract class AssetSyncService(
 ) : SyncService {
     protected fun validateAssetDirectory() {
         if (!assetDirectory.exists()) {
-            println("\uD83D\uDCC1 The '${assetDirectory.name}' folder doesn't exist, creating it..")
+            Logger.info { "\uD83D\uDCC1 The '${assetDirectory.name}' folder doesn't exist, creating it..\n" }
             assetDirectory.createDirectories()
         }
 

--- a/sync-script/src/main/kotlin/utils/Utils.kt
+++ b/sync-script/src/main/kotlin/utils/Utils.kt
@@ -35,7 +35,7 @@ fun showErrorMessageAndTerminate(
             parentComponent = guiParentComponent,
         )
     } else {
-        println("❌ $title: $message")
+        Logger.error { "❌ $title: $message" }
     }
     terminateWithOrWithoutError()
 }


### PR DESCRIPTION
The current logging solution is still inadequate and needs improvement. This PR makes it easier to track the log messages or
migrate later, we have considered using Kotlin logging solutions though most of them depend on a Java logging library for the JVM implementation, which makes the bundle size bigger (0.10 MB to 6 MB).

Notice the messages that are printed to the log will be shown when running the script using the command line or in the launcher, which is why we avoided printing log info at the start of the message: `[main] INFO Main - ${message}`.

We might use Java logging since it's already part of the JDK and will be used in development mode to filter the messages by log level and scope.