### PR TITLE
fix: apply resource packs in the specified order

### DIFF
--- a/sync-script/src/main/kotlin/syncService/ResourcePacksSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ResourcePacksSyncService.kt
@@ -66,7 +66,7 @@ class ResourcePacksSyncService :
         )
 
         if (resourcePackSyncInfo.applyResourcePacks) {
-            applyResourcePacks()
+            applyResourcePacks(resourcePacks = resourcePacks)
         }
 
         Logger.info {
@@ -191,9 +191,10 @@ class ResourcePacksSyncService :
         }
     }
 
-    private suspend fun applyResourcePacks() {
-        val resourcePackFilePaths = getScriptLocalResourcePackFilePathsOrAll()
-
+    /**
+     * @param resourcePacks The list of resource packs to apply, the ones that are synced using the script
+     * */
+    private fun applyResourcePacks(resourcePacks: List<ResourcePack>) {
         MinecraftOptionsManager.loadPropertiesFromFile(createIfMissing = true)
 
         val optionsResourcePacks: List<MinecraftOptionsManager.ResourcePack>? =
@@ -215,8 +216,9 @@ class ResourcePacksSyncService :
                         userOptionsResourcePacks?.let { addAll(userOptionsResourcePacks) }
                     }
                     addAll(
-                        resourcePackFilePaths
-                            .map { MinecraftOptionsManager.ResourcePack.File(it.name) },
+                        resourcePacks.map {
+                            MinecraftOptionsManager.ResourcePack.File(getResourcePackFilePath(it).name)
+                        },
                     )
                 },
         )


### PR DESCRIPTION
When the option `applyResourcePacks` is `true`:

```json
{
  "resourcePackSyncInfo": {
    "applyResourcePacks": true,
    "resourcePacks": [
      {
        "downloadUrl": "https://cdn.example.com/data/RRxvWKNL/versions/roiZsJIW/ResourcePack1.zip"
      },
      {
        "downloadUrl": "https://cdn.example.com/data/U5SedG9S/versions/3fjew8Kj/ResourcePack2.zip"
      },
      {
        "downloadUrl": "https://cdn.example.com/data/dspKZXKP/versions/1lwmCieT/ResourcePack3.zip"
      }
    ]
  }
}
```

The script previously did not apply the resource packs in the specified order. Now, resource packs will be applied in the order listed, aligning with how Minecraft stores the list of applied resource packs in `options.txt` (which is stored in `.minecraft`). Items at the beginning of the list have lower priority, while those at the end have higher priority. For example:

```
resourcePacks:["file/ResourcePack1.zip", "file/ResourcePack2.zip", "file/ResourcePack3.zip"]
```

In this order, `ResourcePack3.zip` has the highest priority, and `ResourcePack1.zip` has the lowest.

> [!NOTE]
> This feature is still considered to be experimental.