### PR TITLE
feat: basic support for syncing custom files

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="version" value="2.1.0" />
   </component>
 </project>

--- a/common/src/main/kotlin/syncInfo/models/SyncInfo.kt
+++ b/common/src/main/kotlin/syncInfo/models/SyncInfo.kt
@@ -1,6 +1,7 @@
 package syncInfo.models
 
 import kotlinx.serialization.Serializable
+import syncInfo.models.customFile.CustomFileSyncInfo
 import syncInfo.models.mod.ModSyncInfo
 import syncInfo.models.resourcePack.ResourcePackSyncInfo
 import syncInfo.models.server.ServerSyncInfo
@@ -44,6 +45,10 @@ data class SyncInfo(
      * All required and optional properties for the server syncing process
      * */
     val serverSyncInfo: ServerSyncInfo = ServerSyncInfo(),
+    /**
+     * All required and optional properties for the custom file syncing process.
+     * */
+    val customFileSyncInfo: CustomFileSyncInfo? = null,
 ) {
     companion object
 }

--- a/common/src/main/kotlin/syncInfo/models/customFile/CustomFile.kt
+++ b/common/src/main/kotlin/syncInfo/models/customFile/CustomFile.kt
@@ -1,0 +1,30 @@
+package syncInfo.models.customFile
+
+import kotlinx.serialization.Serializable
+import syncInfo.models.FileIntegrityInfo
+import syncInfo.models.SyncInfo
+
+@Serializable
+data class CustomFile(
+    /**
+     * Specifies the file path where the file will be stored relative to the current working directory,
+     * which corresponds to the `.minecraft` directory (located alongside the `mods` directory).
+     *
+     * For example,
+     * If the specified path is `config/mod-config.json` and the `.minecraft` directory is
+     * `C:\Users\Username\AppData\Roaming\.minecraft`, the resulting file will be created at:
+     * `C:\Users\Username\AppData\Roaming\.minecraft\config\mod-config.json`.
+     *
+     * The content of this file will be sourced from [downloadUrl].
+     *
+     * The file and all necessary parent directories will be created recursively.
+     * */
+    val filePath: String,
+    val downloadUrl: String,
+    val fileIntegrityInfo: FileIntegrityInfo = FileIntegrityInfo(),
+    /**
+     * Overrides [CustomFileSyncInfo.verifyFilesIntegrity] and [SyncInfo.verifyAssetFilesIntegrity]
+     * for a file.
+     * */
+    val verifyFileIntegrity: Boolean? = null,
+)

--- a/common/src/main/kotlin/syncInfo/models/customFile/CustomFileSyncInfo.kt
+++ b/common/src/main/kotlin/syncInfo/models/customFile/CustomFileSyncInfo.kt
@@ -1,0 +1,29 @@
+package syncInfo.models.customFile
+
+import kotlinx.serialization.Serializable
+import syncInfo.models.FileIntegrityInfo
+import syncInfo.models.SyncInfo
+
+@Serializable
+data class CustomFileSyncInfo(
+    /**
+     * List of custom files to sync.
+     * */
+    val files: List<CustomFile> = emptyList(),
+    /**
+     * Indicates whether the script should delete files that are no longer listed.
+     * If set to `true`, files removed from [files] will be deleted during the sync process.
+     *
+     * This will only delete the files, but not the parent directories that have been created by the script,
+     * and they might remain empty.
+     */
+    val deleteRemovedFiles: Boolean = false,
+    /**
+     * Overrides [SyncInfo.verifyAssetFilesIntegrity] for the custom files.
+     *
+     * See [CustomFile.verifyFileIntegrity] to override this value for a file.
+     *
+     * @see FileIntegrityInfo
+     * */
+    val verifyFilesIntegrity: Boolean? = null,
+)

--- a/common/src/main/kotlin/utils/SharedUtils.kt
+++ b/common/src/main/kotlin/utils/SharedUtils.kt
@@ -27,7 +27,7 @@ fun getFileNameFromUrl(url: String): Result<String?> {
             return Result.failure(IllegalArgumentException("Provided URL cannot be empty or blank."))
         }
         val parts = url.split("/")
-        val fileName = if (parts.isNotEmpty()) URLDecoder.decode(parts.last(), "UTF-8") else null
+        val fileName = if (parts.isNotEmpty()) URLDecoder.decode(parts.last(), "UTF-8").substringBefore("?") else null
         Result.success(fileName)
     } catch (e: Exception) {
         e.printStackTrace()

--- a/common/src/test/kotlin/utils/SharedUtilsTest.kt
+++ b/common/src/test/kotlin/utils/SharedUtilsTest.kt
@@ -38,6 +38,14 @@ class SharedUtilsTest {
     }
 
     @Test
+    fun `getFileNameFromUrl removes query parameters if exist`() {
+        assertEquals(
+            "build.gradle.kts",
+            getFileNameFromUrl("https://github.com/FreshKernel/kraft-sync/blob/main/sync-script/build.gradle.kts?raw=true").getOrThrow()
+        )
+    }
+
+    @Test
     fun `test isValidUrl`() {
         assertEquals(
             "http://example.com".isValidUrl(),

--- a/sync-script/src/main/kotlin/Main.kt
+++ b/sync-script/src/main/kotlin/Main.kt
@@ -20,6 +20,7 @@ import syncInfo.data.RemoteSyncInfoDataSource
 import syncInfo.data.SyncInfoDataSource
 import syncInfo.models.SyncInfo
 import syncInfo.models.instance
+import syncService.CustomFileSyncService
 import syncService.ModsSyncService
 import syncService.ResourcePacksSyncService
 import syncService.ServersSyncService
@@ -304,6 +305,7 @@ private suspend fun performSyncServices(scriptConfig: ScriptConfig) {
                 add(ResourcePacksSyncService())
                 add(ServersSyncService())
             }
+            add(CustomFileSyncService())
         }
 
     syncServices.forEach { it.syncData() }

--- a/sync-script/src/main/kotlin/constants/SyncScriptDotMinecraftFiles.kt
+++ b/sync-script/src/main/kotlin/constants/SyncScriptDotMinecraftFiles.kt
@@ -40,14 +40,14 @@ sealed class SyncScriptDotMinecraftFiles(
         /**
          * The script needs a config file that contains required data and other optional to configure it
          * */
-        data object ScriptConfig : SyncScriptDotMinecraftFiles(SyncScriptData.path.resolve("config.json"))
+        data object ScriptConfig : SyncScriptDotMinecraftFiles(path.resolve("config.json"))
 
         /**
          * A directory that contain the temporary files used by the script,
          * for example, when downloading a file, the content will be saved to this directory
          * and after finish downloading, the file will be moved into where it should.
          * */
-        data object Temp : SyncScriptDotMinecraftFiles(SyncScriptData.path.resolve("temp"))
+        data object Temp : SyncScriptDotMinecraftFiles(path.resolve("temp"))
 
         /**
          * A file will be used to indicate if the user did set up the preferences for using the script, and it will
@@ -57,6 +57,13 @@ sealed class SyncScriptDotMinecraftFiles(
          * it later and launch the dialog again.
          * */
         data object IsPreferencesConfigured :
-            SyncScriptDotMinecraftFiles(SyncScriptData.path.resolve("isPreferencesConfigured"))
+            SyncScriptDotMinecraftFiles(path.resolve("isPreferencesConfigured"))
+
+        /**
+         * Stores the custom files that have been stored previously by the script on the last run.
+         * Allows the script to delete the removed files from
+         * the list ([syncInfo.models.customFile.CustomFileSyncInfo.files]) to sync them with the remote.
+         * */
+        data object CustomSyncedFiles : SyncScriptDotMinecraftFiles(path.resolve("customSyncedFiles.json"))
     }
 }

--- a/sync-script/src/main/kotlin/gui/dialogs/LoadingIndicatorDialog.kt
+++ b/sync-script/src/main/kotlin/gui/dialogs/LoadingIndicatorDialog.kt
@@ -89,9 +89,9 @@ class LoadingIndicatorDialog(
         progress: Int?,
         detailsText: String?,
     ) {
-        title?.let { this.title = it }
-        infoText?.let { infoLabel.text = it }
-        progress?.let { progressBar.value = it }
-        detailsText?.let { detailsLabel.text = it }
+        this.title = title.orEmpty()
+        infoLabel.text = infoText.orEmpty()
+        progressBar.value = progress ?: 0
+        detailsLabel.text = detailsText.orEmpty()
     }
 }

--- a/sync-script/src/main/kotlin/services/updater/JarAutoUpdater.kt
+++ b/sync-script/src/main/kotlin/services/updater/JarAutoUpdater.kt
@@ -71,7 +71,7 @@ object JarAutoUpdater {
                                 " ${bytesToDownload.convertBytesToReadableMegabytesAsString()} MB",
                     )
                 },
-            ).downloadFile()
+            ).downloadFile(fileEntityType = "JAR")
             Result.success(newJarFile)
         } catch (e: Exception) {
             e.printStackTrace()

--- a/sync-script/src/main/kotlin/syncInfo/models/CustomFileExtensions.kt
+++ b/sync-script/src/main/kotlin/syncInfo/models/CustomFileExtensions.kt
@@ -1,0 +1,24 @@
+package syncInfo.models
+
+import syncInfo.models.customFile.CustomFile
+import utils.showErrorMessageAndTerminate
+import java.nio.file.Path
+import kotlin.io.path.name
+import kotlin.system.exitProcess
+
+/**
+ * Whether to validate the file integrity. Can set globally to all files or all custom files or a specific custom file.
+ * */
+fun CustomFile.shouldVerifyFileIntegrity(): Boolean =
+    verifyFileIntegrity ?: SyncInfo.instance.customFileSyncInfo?.verifyFilesIntegrity
+    ?: SyncInfo.instance.verifyAssetFilesIntegrity
+
+suspend fun CustomFile.hasValidFileIntegrityOrError(filePath: Path): Boolean? =
+    this.fileIntegrityInfo.hasValidIntegrity(filePath = filePath).getOrElse {
+        showErrorMessageAndTerminate(
+            title = "File Integrity Validation Error ⚠️",
+            message = "An error occurred while validating the integrity of the custom-file file (${filePath.name}) \uD83D\uDCC1.",
+        )
+        // This will never reach due to the previous statement stopping the application
+        exitProcess(1)
+    }

--- a/sync-script/src/main/kotlin/syncService/CustomFileSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/CustomFileSyncService.kt
@@ -1,0 +1,194 @@
+package syncService
+
+import constants.SyncScriptDotMinecraftFiles
+import gui.dialogs.LoadingIndicatorDialog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import syncInfo.models.SyncInfo
+import syncInfo.models.customFile.CustomFile
+import syncInfo.models.hasValidFileIntegrityOrError
+import syncInfo.models.instance
+import syncInfo.models.shouldVerifyFileIntegrity
+import utils.ExecutionTimer
+import utils.FileDownloader
+import utils.Logger
+import utils.calculateProgressByIndex
+import utils.convertBytesToReadableMegabytesAsString
+import utils.createParentDirectoriesIfDoesNotExist
+import utils.deleteExistingOrTerminate
+import utils.getFileNameFromUrlOrError
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+import kotlin.io.path.name
+import kotlin.io.path.pathString
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class CustomFileSyncService : SyncService {
+    private val customFileSyncService = SyncInfo.instance.customFileSyncInfo
+
+    override suspend fun syncData() = withContext(Dispatchers.IO) {
+        if (customFileSyncService == null) {
+            return@withContext
+        }
+
+        val executionTimer = ExecutionTimer()
+        executionTimer.setStartTime()
+        Logger.info(extraLine = true) { "\uD83D\uDD04 Syncing custom files..." }
+
+        val customFiles = customFileSyncService.files
+        Logger.info { "📥 Total received custom files from server: ${customFiles.size}" }
+
+        deleteRemovedFiles(customFiles)
+
+        LoadingIndicatorDialog.instance?.updateComponentProperties(
+            title = "Syncing Custom-files...",
+            infoText = "In progress",
+            progress = null,
+            detailsText = null,
+        )
+
+        val customFilesToDownload = getCustomFilesForDownloadAndValidateIfRequired(customFiles)
+
+        Logger.info(extraLine = true) { "🔍 Custom-files to download: ${customFilesToDownload.size}" }
+
+        downloadCustomFiles(customFilesToDownload)
+
+        updateCustomSyncedFiles(customFiles)
+
+        Logger.info {
+            "\uD83D\uDD52 Finished syncing the custom-files in ${executionTimer.getRunningUntilNowDuration().inWholeMilliseconds}ms."
+        }
+    }
+
+    /**
+     * Delete custom files that have been created by the script previously, but no longer exist in the list.
+     * */
+    private fun deleteRemovedFiles(remoteCustomFiles: List<CustomFile>) {
+        if (customFileSyncService?.deleteRemovedFiles == false) {
+            Logger.info {
+                "ℹ️ The server configuration is set to retain removed files. If the server deletes a custom file" +
+                        ", it will not be removed locally."
+            }
+            return
+        }
+        val customSyncedFilesFilePath = SyncScriptDotMinecraftFiles.SyncScriptData.CustomSyncedFiles.path
+        if (!customSyncedFilesFilePath.exists()) {
+            Logger.info {
+                "ℹ️ The custom synced files does not exist: ${customSyncedFilesFilePath.pathString}." +
+                        "Skip deleting the removed files to the next run."
+            }
+            return
+        }
+
+        val currentSyncedFiles =
+            Json.decodeFromString<List<CustomFile>>(customSyncedFilesFilePath.readText())
+
+        Logger.info { "ℹ️ The current synced files size: ${currentSyncedFiles.size}" }
+
+        for (localCustomFile in currentSyncedFiles) {
+            val customFilePath = localCustomFile.asJavaFilePath
+
+            if (localCustomFile !in remoteCustomFiles) {
+                Logger.info {
+                    "\uD83D\uDEAB Deleting the custom file '${customFilePath.name}' as it no longer " +
+                            "exists in the remote custom files list."
+                }
+                customFilePath.deleteExistingOrTerminate(
+                    fileEntityType = "custom",
+                    reasonOfDelete = "it's no longer on the server",
+                )
+            }
+        }
+    }
+
+    private suspend fun getCustomFilesForDownloadAndValidateIfRequired(customFiles: List<CustomFile>) =
+        customFiles.filter { customFile ->
+            val customFileName = getFileNameFromUrlOrError(customFile.downloadUrl)
+            val customFilePath = customFile.asJavaFilePath
+
+            if (customFilePath.exists()) {
+                if (!customFile.shouldVerifyFileIntegrity()) {
+                    Logger.info {
+                        "ℹ️ The custom-file: '$customFileName' is set to not be verified. Skipping to the next custom-file."
+                    }
+                    return@filter false
+                }
+
+                LoadingIndicatorDialog.instance?.updateComponentProperties(
+                    title =
+                        "Verifying custom-files",
+                    infoText = buildVerifyFileMessage(fileDisplayName = customFileName),
+                    progress =
+                        customFiles.calculateProgressByIndex(currentIndex = customFiles.indexOf(customFile)),
+                    detailsText =
+                        "Verifying the custom files integrity...",
+                )
+
+                val hasValidCustomFileIntegrity = customFile.hasValidFileIntegrityOrError(customFilePath)
+                if (hasValidCustomFileIntegrity == null) {
+                    Logger.info { "❓ The custom-file: '$customFileName' has an unknown integrity. Skipping to the next custom-file." }
+                    return@filter false
+                }
+                if (hasValidCustomFileIntegrity) {
+                    Logger.info { "✅ The custom-file: '$customFileName' has valid file integrity. Skipping to the next custom-file." }
+                    return@filter false
+                }
+                Logger.info {
+                    "\uD83D\uDEAB The custom-file: '$customFileName' has invalid integrity. Deleting the file and downloading it again."
+                }
+                customFilePath.deleteExistingOrTerminate(
+                    fileEntityType = "custom-file",
+                    reasonOfDelete = "it has invalid file integrity",
+                )
+            }
+            // Add this custom-file to the download list.
+            true
+        }
+
+    private suspend fun downloadCustomFiles(customFiles: List<CustomFile>) {
+        for ((index, customFile) in customFiles.withIndex()) {
+            val customFileName = getFileNameFromUrlOrError(customFile.downloadUrl)
+            val customFilePath = Path(customFile.filePath)
+
+            if (customFilePath.exists()) {
+                Logger.warning { "⚠\uFE0F The custom-file: '$customFileName' already exists." }
+            }
+
+            Logger.info { "\uD83D\uDD3D Downloading custom-file '$customFileName' from ${customFile.downloadUrl}" }
+
+            // Important so the FileDownloader can create the file.
+            customFilePath.createParentDirectoriesIfDoesNotExist()
+
+            FileDownloader(
+                downloadUrl = customFile.downloadUrl,
+                targetFilePath = customFilePath,
+                progressListener = { downloadedBytes, downloadedProgress, bytesToDownload ->
+                    LoadingIndicatorDialog.instance?.updateComponentProperties(
+                        title =
+                            buildProgressMessage(
+                                currentIndex = index,
+                                pendingCount = customFiles.size,
+                                totalCount = customFiles.size,
+                            ),
+                        infoText =
+                            buildDownloadFileMessage(fileDisplayName = customFileName),
+                        progress = downloadedProgress.toInt(),
+                        detailsText =
+                            "${downloadedBytes.convertBytesToReadableMegabytesAsString()} MB /" +
+                                    " ${bytesToDownload.convertBytesToReadableMegabytesAsString()} MB",
+                    )
+                }
+            ).downloadFile(fileEntityType = "Custom")
+        }
+    }
+
+    private fun updateCustomSyncedFiles(customFiles: List<CustomFile>) {
+        val filePath = SyncScriptDotMinecraftFiles.SyncScriptData.CustomSyncedFiles.path
+        filePath.writeText(Json.encodeToString<List<CustomFile>>(customFiles))
+    }
+
+    private val CustomFile.asJavaFilePath
+        get() = Path(this.filePath)
+}

--- a/sync-script/src/main/kotlin/syncService/ModsSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ModsSyncService.kt
@@ -137,7 +137,7 @@ class ModsSyncService :
                 LoadingIndicatorDialog.instance?.updateComponentProperties(
                     title =
                         "Verifying mods",
-                    infoText = buildVerifyAssetFileMessage(assetDisplayName = mod.getDisplayName()),
+                    infoText = buildVerifyFileMessage(fileDisplayName = mod.getDisplayName()),
                     progress =
                         mods.calculateProgressByIndex(currentIndex = mods.indexOf(mod)),
                     detailsText =
@@ -191,14 +191,14 @@ class ModsSyncService :
                                 totalCount = totalMods.size,
                             ),
                         infoText =
-                            buildDownloadAssetFileMessage(assetDisplayName = mod.getDisplayName()),
+                            buildDownloadFileMessage(fileDisplayName = mod.getDisplayName()),
                         progress = downloadedProgress.toInt(),
                         detailsText =
                             "${downloadedBytes.convertBytesToReadableMegabytesAsString()} MB /" +
                                 " ${bytesToDownload.convertBytesToReadableMegabytesAsString()} MB",
                     )
                 },
-            ).downloadFile()
+            ).downloadFile(fileEntityType = "Mod JAR")
 
             // This will always validate newly downloaded mods regardless of the configurations
             val isNewlyDownloadedFileHasValidFileIntegrity = mod.hasValidFileIntegrityOrError(modFilePath)

--- a/sync-script/src/main/kotlin/syncService/ResourcePacksSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/ResourcePacksSyncService.kt
@@ -111,7 +111,7 @@ class ResourcePacksSyncService :
                 LoadingIndicatorDialog.instance?.updateComponentProperties(
                     title =
                         "Verifying Resource Packs",
-                    infoText = buildVerifyAssetFileMessage(assetDisplayName = resourcePack.getDisplayName()),
+                    infoText = buildVerifyFileMessage(fileDisplayName = resourcePack.getDisplayName()),
                     progress =
                         resourcePacks.calculateProgressByIndex(currentIndex = resourcePacks.indexOf(resourcePack)),
                     detailsText =
@@ -168,14 +168,14 @@ class ResourcePacksSyncService :
                                 pendingCount = resourcePacksToDownload.size,
                                 totalCount = totalResourcePacks.size,
                             ),
-                        infoText = buildDownloadAssetFileMessage(assetDisplayName = resourcePack.getDisplayName()),
+                        infoText = buildDownloadFileMessage(fileDisplayName = resourcePack.getDisplayName()),
                         progress = downloadedProgress.toInt(),
                         detailsText =
                             "${downloadedBytes.convertBytesToReadableMegabytesAsString()} MB /" +
                                 " ${bytesToDownload.convertBytesToReadableMegabytesAsString()} MB",
                     )
                 },
-            ).downloadFile()
+            ).downloadFile(fileEntityType = "Resource pack")
 
             // This will always validate newly downloaded resource-packs regardless of the configurations
             val isNewlyDownloadedFileHasValidFileIntegrity =

--- a/sync-script/src/main/kotlin/syncService/SyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/SyncService.kt
@@ -1,8 +1,44 @@
 package syncService
 
+import utils.buildHtml
+
 /**
  * This interface defines a contract for services that will sync the data
  * */
 interface SyncService {
     suspend fun syncData()
+
+    /**
+     * @return The message that will be used for the dialog that will show the progress
+     * of syncing, downloading, and verifying items.
+     *
+     * @param currentIndex The index of the current item being processed (0-based index).
+     * @param pendingCount The number of items remaining to be processed or downloaded.
+     * @param totalCount The total number of items that should be processed or present in [assetDirectory].
+     *
+     * @return The progress message indicating the current state of the process.
+     * */
+    fun buildProgressMessage(
+        currentIndex: Int,
+        pendingCount: Int,
+        totalCount: Int,
+    ): String =
+        buildString {
+            append("${currentIndex + 1} of $pendingCount")
+            if (pendingCount != totalCount) {
+                append(" ($totalCount total)")
+            }
+        }
+
+    fun buildDownloadFileMessage(fileDisplayName: String): String =
+        buildHtml {
+            text("Downloading ")
+            boldText(fileDisplayName)
+        }.buildBodyAsText()
+
+    fun buildVerifyFileMessage(fileDisplayName: String): String =
+        buildHtml {
+            text("Verifying ")
+            boldText(fileDisplayName)
+        }.buildBodyAsText()
 }

--- a/sync-script/src/main/kotlin/syncService/common/AssetSyncService.kt
+++ b/sync-script/src/main/kotlin/syncService/common/AssetSyncService.kt
@@ -111,38 +111,4 @@ abstract class AssetSyncService(
                 exitProcess(1)
             }
     }
-
-    /**
-     * @return The message that will be used for the dialog that will show the progress
-     * of syncing, downloading, and verifying items.
-     *
-     * @param currentIndex The index of the current item being processed (0-based index).
-     * @param pendingCount The number of items remaining to be processed or downloaded.
-     * @param totalCount The total number of items that should be processed or present in [assetDirectory].
-     *
-     * @return The progress message indicating the current state of the process.
-     * */
-    protected fun buildProgressMessage(
-        currentIndex: Int,
-        pendingCount: Int,
-        totalCount: Int,
-    ): String =
-        buildString {
-            append("${currentIndex + 1} of $pendingCount")
-            if (pendingCount != totalCount) {
-                append(" ($totalCount total)")
-            }
-        }
-
-    protected fun buildDownloadAssetFileMessage(assetDisplayName: String): String =
-        buildHtml {
-            text("Downloading ")
-            boldText(assetDisplayName)
-        }.buildBodyAsText()
-
-    protected fun buildVerifyAssetFileMessage(assetDisplayName: String): String =
-        buildHtml {
-            text("Verifying ")
-            boldText(assetDisplayName)
-        }.buildBodyAsText()
 }


### PR DESCRIPTION
Allows to sync custom files, and remove them if they are no longer on the custom files list from the remote sync info file:

```json
"customFileSyncInfo": {
    "deleteRemovedFiles": true,
    "files": [
      {
        "downloadUrl": "https://github.com/FreshKernel/kraft-sync/blob/main/sync-script/build.gradle.kts?raw=true",
        "filePath": "config/config.json"
      }
    ]
  }
```

The file path is not specific to the `.minecraft` directory although the current working directory is the same as the script executable, which is `.minecraft` (alongside the `mods` directory).

This project is no longer supported as it was as I'm not very motivated to work on it, and I will only post simple changes to fit some requirements without maintenance or quality updates.